### PR TITLE
Add env examples and project README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Example environment variables for NexusA.I
+
+# Stripe configuration
+STRIPE_SECRET_KEY=your_stripe_secret_key
+STRIPE_PUBLISHABLE_KEY=your_stripe_publishable_key
+STRIPE_PRICE_ID=your_stripe_price_id
+
+# OpenAI API Key (optional for backtester logic)
+OPENAI_API_KEY=your_openai_key
+
+# Enable Flask debug mode: set to 0 in production
+FLASK_DEBUG=1

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ Pipfile.lock
 # Backtesting results
 uploads/
 static/results/
+
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# NexusA.I
+
+This Flask application provides an interface for backtesting trading strategies and integrates Stripe for payments.
+
+## Setup
+
+1. Clone the repository and install the dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copy `.env.example` to `.env` and fill in your credentials:
+   ```bash
+   cp .env.example .env
+   # edit .env and set STRIPE and OPENAI keys
+   ```
+3. Run the application locally:
+   ```bash
+   python app.py
+   ```
+
+The application reads configuration from environment variables using `python-dotenv`. The most important variables are:
+
+- `STRIPE_SECRET_KEY` – your Stripe secret key
+- `STRIPE_PUBLISHABLE_KEY` – your Stripe publishable key
+- `STRIPE_PRICE_ID` – the price ID for the checkout session
+- `OPENAI_API_KEY` – optional key used by the backtester logic
+- `FLASK_DEBUG` – set to `1` to enable debug mode
+
+## Deployment
+
+A simple `render.yaml` is included for deployment to Render. Adjust the environment variables there as needed.


### PR DESCRIPTION
## Summary
- ignore `.env`
- add `.env.example` with placeholder secrets
- document environment setup in new `README.md`

## Testing
- `python -m py_compile app.py my_backtester_logic.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685a48c25f888330824d8506c81dfa95