### PR TITLE
Document DB migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ This Flask application provides an interface for backtesting trading strategies 
    cp .env.example .env
    # edit .env and set STRIPE and OPENAI keys
    ```
-3. Run the application locally:
+3. Initialize the database using Flask-Migrate:
+   ```bash
+   flask db upgrade
+   ```
+4. Run the application locally:
    ```bash
    python app.py
    ```

--- a/render.yaml
+++ b/render.yaml
@@ -3,4 +3,4 @@ services:
     name: nexus-backtester
     env: python
     buildCommand: "pip install -r requirements.txt"
-    startCommand: "gunicorn app:app"
+    startCommand: "flask db upgrade && gunicorn app:app"


### PR DESCRIPTION
## Summary
- document running `flask db upgrade` before starting the app
- run the upgrade automatically in render's start command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685b8d73e9348330b621b3ebd1bc9c89