### PR TITLE
Add Stripe payment redirect endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ The application reads configuration from environment variables using `python-dot
 - `OPENAI_API_KEY` – optional key used by the backtester logic
 - `FLASK_DEBUG` – set to `1` to enable debug mode
 
+### Stripe pricing table
+
+When configuring your pricing table in the Stripe Dashboard choose **Redirect to your site** after payment.
+
+Use these routes for the final URLs:
+
+```
+Success URL: https://your-domain.com/payment/success?session_id={CHECKOUT_SESSION_ID}
+Cancel URL:  https://your-domain.com/payment/cancel
+```
+
+During local development you can use `http://127.0.0.1:5000` in place of `https://your-domain.com`.
+
 ## Deployment
 
 A simple `render.yaml` is included for deployment to Render. Adjust the environment variables there as needed.

--- a/app.py
+++ b/app.py
@@ -1,4 +1,14 @@
-from flask import Flask, render_template, request, jsonify, send_from_directory, url_for, redirect, session
+from flask import (
+    Flask,
+    render_template,
+    request,
+    jsonify,
+    send_from_directory,
+    url_for,
+    redirect,
+    session,
+    flash,
+)
 import os
 import uuid  # For generating unique job IDs
 import logging  # For logging within Flask app
@@ -140,6 +150,23 @@ def success_page():
     return render_template('success.html')
 
 
+@app.route('/payment/success')
+@login_required
+def payment_success():
+    sess_id = request.args.get('session_id')
+    # Optional: verify the session via Stripe API
+    # stripe.checkout.Session.retrieve(sess_id)
+    flash('Payment received – welcome!')
+    return redirect(url_for('member_dashboard_page'))
+
+
+@app.route('/payment/cancel')
+@login_required
+def payment_cancel():
+    flash('Payment cancelled.')
+    return redirect(url_for('checkout_page'))
+
+
 @app.route('/create-checkout-session', methods=['POST'])
 @login_required
 def create_checkout_session():
@@ -153,8 +180,8 @@ def create_checkout_session():
                 'quantity': 1,
             }],
             mode='payment',
-            success_url=url_for('member_dashboard_page', _external=True) + '?session_id={CHECKOUT_SESSION_ID}',
-            cancel_url=url_for('checkout_page', _external=True),
+            success_url=url_for('payment_success', _external=True) + '?session_id={CHECKOUT_SESSION_ID}',
+            cancel_url=url_for('payment_cancel', _external=True),
         )
         return jsonify({'url': session.url})
     except Exception as e:


### PR DESCRIPTION
## Summary
- add routes for payment success and cancel
- flash a message and redirect accordingly
- use new routes when creating checkout sessions
- document final URL configuration in README

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bb46d98d0833082b3878c9284202b