### PR TITLE
Add AI prompt guide

### DIFF
--- a/app.py
+++ b/app.py
@@ -223,6 +223,11 @@ def how_it_works_page():
     return render_template('how_it_works.html')
 
 
+@app.route('/prompt-guide')
+def prompt_guide_page():
+    return render_template('prompt_guide.html')
+
+
 @app.route('/dashboard')
 @login_required
 def member_dashboard_page():

--- a/templates/member_dashboard.html
+++ b/templates/member_dashboard.html
@@ -130,7 +130,10 @@
                                 <input type="password" name="backtest_openai_api_key" id="backtest_openai_api_key" placeholder="sk-xxxxxxxxxx" required>
                             </div>
                             <div>
-                                <label for="backtest_strategy_prompt" class="block text-sm font-medium mb-1">Custom AI Strategy Prompt</label>
+                                <div class="flex items-center justify-between">
+                                    <label for="backtest_strategy_prompt" class="block text-sm font-medium mb-1">Custom AI Strategy Prompt</label>
+                                    <a href="/prompt-guide" class="secondary-button text-xs px-2 py-1 rounded-md">How to?</a>
+                                </div>
                                 <textarea name="backtest_strategy_prompt" id="backtest_strategy_prompt" rows="8" placeholder="Define your AI's backtesting logic..." required></textarea>
                             </div>
 
@@ -187,7 +190,13 @@
                         <h3 class="text-2xl font-bold text-white mb-6 text-center border-b border-gray-700 pb-4">Live Paper Trading Mode</h3>
                         <form id="paperTradingForm" class="space-y-6">
                             <div><label for="live_openai_api_key" class="block text-sm font-medium mb-1">OpenAI API Key</label><input type="password" name="live_openai_api_key" id="live_openai_api_key" placeholder="sk-xxxxxxxxxx"></div>
-                            <div><label for="live_strategy_prompt" class="block text-sm font-medium mb-1">Custom AI Strategy Prompt</label><textarea name="live_strategy_prompt" id="live_strategy_prompt" rows="8" placeholder="Define your AI's live paper trading logic..."></textarea></div>
+                            <div>
+                                <div class="flex items-center justify-between">
+                                    <label for="live_strategy_prompt" class="block text-sm font-medium mb-1">Custom AI Strategy Prompt</label>
+                                    <a href="/prompt-guide" class="secondary-button text-xs px-2 py-1 rounded-md">How to?</a>
+                                </div>
+                                <textarea name="live_strategy_prompt" id="live_strategy_prompt" rows="8" placeholder="Define your AI's live paper trading logic..."></textarea>
+                            </div>
                             <div class="border-t border-gray-700 pt-6"><h4 class="text-md font-semibold text-gray-300 mb-2">Paper Trading Exchange Connection</h4><div class="space-y-4"><div><label for="paper_exchange" class="block text-sm font-medium mb-1">Select Paper Exchange</label><select name="paper_exchange" id="paper_exchange"><option value="binance_paper">Binance (Paper Account)</option><option value="bybit_paper">Bybit (Testnet/Paper)</option></select></div><div><label for="paper_api_key_live" class="block text-sm font-medium mb-1">Paper Trading API Key</label><input type="text" name="paper_api_key_live" id="paper_api_key_live" placeholder="Enter paper account API key"></div><div><label for="paper_api_secret_live" class="block text-sm font-medium mb-1">Paper Trading API Secret</label><input type="password" name="paper_api_secret_live" id="paper_api_secret_live" placeholder="Enter paper account API secret"></div><p class="text-xs text-yellow-400 mt-1 disclaimer"><strong class="font-bold">Important:</strong> Use API keys for paper trading accounts only.</p></div></div>
                             <div class="pt-4"><button type="submit" id="startPaperTradingButton" class="w-full cta-button text-white px-6 py-3 rounded-lg font-semibold shadow-lg">Start Live Paper Session</button></div>
                         </form>

--- a/templates/prompt_guide.html
+++ b/templates/prompt_guide.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Prompt Guide - NexusTrade AI Lab</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Inter', sans-serif; background-color: #111827; color: #E5E7EB; }
+        .content { background-color: #1F2937; border: 1px solid #374151; }
+        .cta-button { background-color: #3B82F6; transition: background-color 0.3s ease; }
+        .cta-button:hover { background-color: #2563EB; }
+    </style>
+</head>
+<body class="flex flex-col min-h-screen">
+    <nav class="bg-gray-900/80 backdrop-blur-md sticky top-0 z-50 border-b border-gray-700">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16">
+                <div class="flex items-center">
+                    <a href="/" class="text-2xl font-bold text-white">NexusTrade <span class="text-blue-500">AI Lab</span></a>
+                </div>
+            </div>
+        </div>
+    </nav>
+    <main class="flex-grow pt-16">
+        <header class="bg-gray-800 py-12 text-center">
+            <div class="max-w-4xl mx-auto px-4">
+                <h1 class="text-4xl font-extrabold text-white">How to Write an Effective AI Prompt</h1>
+            </div>
+        </header>
+        <section class="py-12">
+            <div class="max-w-3xl mx-auto px-4 space-y-6 content p-6 sm:p-8 rounded-xl shadow-lg">
+                <p class="text-gray-300">Clear instructions help the AI produce better results. Keep these tips in mind when crafting your trading strategy prompts:</p>
+                <ul class="list-disc list-inside space-y-2 text-gray-400">
+                    <li>State your goal for the strategy in one or two sentences.</li>
+                    <li>Provide any important constraints, such as risk limits or preferred indicators.</li>
+                    <li>Mention how trades should be entered and exited.</li>
+                    <li>Be explicit about time frames or assets if they matter.</li>
+                </ul>
+                <p class="text-gray-300">Use short, direct sentences and specify only what is necessary for your backtest or paper session.</p>
+                <div class="text-center pt-4">
+                    <a href="/dashboard" class="cta-button text-white px-6 py-3 rounded-lg font-semibold shadow-lg">Back to Dashboard</a>
+                </div>
+            </div>
+        </section>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `/prompt-guide` page on how to write prompts
- link to the prompt guide from dashboard forms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bf3acdd2c8330abd801b116336d0f