### PR TITLE
Implement functional backtesting

### DIFF
--- a/templates/member_dashboard.html
+++ b/templates/member_dashboard.html
@@ -126,15 +126,22 @@
                         <h3 class="text-2xl font-bold text-white mb-6 text-center border-b border-gray-700 pb-4">Backtesting Mode</h3>
                         <form id="backtestingForm" class="space-y-6">
                             <div>
-                                <label for="backtest_openai_api_key" class="block text-sm font-medium mb-1">OpenAI API Key</label>
-                                <input type="password" name="backtest_openai_api_key" id="backtest_openai_api_key" placeholder="sk-xxxxxxxxxx" required>
-                            </div>
-                            <div>
                                 <div class="flex items-center justify-between">
                                     <label for="backtest_strategy_prompt" class="block text-sm font-medium mb-1">Custom AI Strategy Prompt</label>
                                     <a href="/prompt-guide" class="secondary-button text-xs px-2 py-1 rounded-md">How to?</a>
                                 </div>
                                 <textarea name="backtest_strategy_prompt" id="backtest_strategy_prompt" rows="8" placeholder="Define your AI's backtesting logic..." required></textarea>
+                            </div>
+
+                            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                <div>
+                                    <label for="starting_balance_usd" class="block text-sm font-medium mb-1">Starting Balance (USD)</label>
+                                    <input type="number" step="0.01" name="starting_balance_usd" id="starting_balance_usd" value="10000">
+                                </div>
+                                <div>
+                                    <label for="trade_amount_btc" class="block text-sm font-medium mb-1">Trade Amount (BTC)</label>
+                                    <input type="number" step="0.001" name="trade_amount_btc" id="trade_amount_btc" value="0.01">
+                                </div>
                             </div>
 
                             <div class="space-y-2">
@@ -165,6 +172,10 @@
                                     <select name="backtest_randomize_period_csv" id="backtest_randomize_period_csv">
                                         <option value="yes" selected>Yes</option> <option value="no">No (use latest)</option>
                                     </select>
+                                </div>
+                                <div class="flex items-center">
+                                    <input type="checkbox" name="use_builtin_btc" id="use_builtin_btc" class="mr-2">
+                                    <label for="use_builtin_btc" class="text-sm font-medium">Use sample BTC data</label>
                                 </div>
                             </div>
 
@@ -208,7 +219,7 @@
                     <div id="equityCurvePlaceholder" class="bg-gray-700 min-h-[200px] rounded-md flex items-center justify-center text-gray-400 mb-6">Equity Curve / Performance Chart Will Appear Here</div>
                     <div id="statsPlaceholder" class="text-gray-300 space-y-2"><p><strong>Status:</strong> <span id="statusText">Pending...</span></p><p><strong>Mode:</strong> <span id="modeText">-</span></p><p><strong>Job ID:</strong> <span id="jobIdText">-</span></p><p><strong>Final Equity:</strong> <span id="finalEquityText">-</span></p><p><strong>Net P/L:</strong> <span id="netPLText">-</span></p><p><strong>Total Trades:</strong> <span id="totalTradesText">-</span></p><p><a href="#" id="tradeLogLink" class="text-blue-400 hover:underline" style="display:none;" target="_blank">Download Full Trade Log (CSV)</a></p><p><a href="#" id="equityCurveLink" class="text-blue-400 hover:underline" style="display:none;" target="_blank">View Equity Curve Image</a></p></div>
                 </div>
-                 <p class="text-xs text-center text-gray-500 mt-8">(Backend interaction is conceptual in this mockup.)</p>
+                <p class="text-xs text-center text-gray-500 mt-8">Results will appear above after processing.</p>
             </div>
         </section>
     </main>
@@ -295,11 +306,17 @@
                 // }
                 // Ensure file is correctly appended if not already handled by FormData(form)
                 const csvFileInput = document.getElementById('backtest_csv_data');
+                const builtinCheckbox = document.getElementById('use_builtin_btc');
+                if (builtinCheckbox) {
+                    builtinCheckbox.addEventListener('change', () => {
+                        csvFileInput.disabled = builtinCheckbox.checked;
+                    });
+                }
                 if (formData.get('dataSource') === 'csv' && csvFileInput.files.length > 0) {
                     // FormData(form) should already include the file if the input has a name attribute.
                     // If you were manually constructing FormData, you'd do:
                     // formData.append('backtest_csv_data', csvFileInput.files[0]);
-                } else if (formData.get('dataSource') === 'csv' && csvFileInput.files.length === 0) {
+                } else if (formData.get('dataSource') === 'csv' && csvFileInput.files.length === 0 && !(builtinCheckbox && builtinCheckbox.checked)) {
                     statusText.textContent = 'Error: Please select a CSV file for backtesting.';
                     equityCurvePlaceholder.innerHTML = '<p class="text-red-400">Error: No CSV file selected.</p>';
                     return; // Stop if CSV is selected but no file


### PR DESCRIPTION
## Summary
- connect the backtesting form with the backend
- allow using built-in BTC data
- remove OpenAI key input from dashboard
- support custom balance and trade size parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bfaede418833082cf23a10fc93742