### PR TITLE
Fix hosted prompt variable passing

### DIFF
--- a/my_backtester_logic.py
+++ b/my_backtester_logic.py
@@ -38,8 +38,7 @@ def call_hosted_prompt(variables: dict, api_key: str, model: str, prompt_id: str
     client = openai.OpenAI(api_key=api_key)
     try:
         response = client.responses.create(
-            prompt={"id": prompt_id, "version": prompt_version},
-            variables=variables,
+            prompt={"id": prompt_id, "version": prompt_version, "variables": variables},
             model=model,
             response_format={"type": "json_object"},
             temperature=temperature,


### PR DESCRIPTION
## Summary
- update `call_hosted_prompt` to attach variables inside the prompt payload

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0d4875708330bff5ef2ada958246