### PR TITLE
Add user list page

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ During local development you can use `http://127.0.0.1:5000` in place of `https:
 ## Deployment
 
 A simple `render.yaml` is included for deployment to Render. Adjust the environment variables there as needed.
+
+## Viewing Users
+
+Once logged in, you can visit `/users` to see a table of all registered accounts. The page displays each user's ID, email and whether they have completed payment.

--- a/app.py
+++ b/app.py
@@ -235,6 +235,14 @@ def prompt_guide_page():
     return render_template('prompt_guide.html')
 
 
+@app.route('/users')
+@login_required
+def list_users_page():
+    """Display a simple table of registered users."""
+    users = User.query.all()
+    return render_template('users.html', users=users)
+
+
 @app.route('/dashboard')
 @login_required
 def member_dashboard_page():

--- a/templates/users.html
+++ b/templates/users.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>User List - NexusTrade AI</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Inter', sans-serif; background-color: #111827; color: #E5E7EB; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border-bottom: 1px solid #374151; padding: 0.75rem; text-align: left; }
+        th { background-color: #1F2937; }
+        tr:nth-child(even) { background-color: #1F2937; }
+    </style>
+</head>
+<body class="min-h-screen p-8">
+    <h1 class="text-2xl font-semibold mb-4">Registered Users</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Email</th>
+                <th>Paid</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for user in users %}
+            <tr>
+                <td>{{ user.id }}</td>
+                <td>{{ user.email }}</td>
+                <td>{{ 'Yes' if user.is_paid else 'No' }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show all users via `/users`
- document new route in README
- add basic template to render user list

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68624d86ea54833081110c8f9d737b42