### PR TITLE
Add user list page

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ During local development you can use `http://127.0.0.1:5000` in place of `https:
 ## Deployment
 
 A simple `render.yaml` is included for deployment to Render. Adjust the environment variables there as needed.
+
+## Viewing Users
+
+Once logged in, the account `prendergast307@gmail.com` can visit `/users` to see a table of all registered accounts. Other logged in users will receive a 403 error. The page displays each user's ID, email and whether they have completed payment.

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from flask import (
     redirect,
     session,
     flash,
+    abort,
 )
 import os
 import uuid  # For generating unique job IDs
@@ -233,6 +234,16 @@ def how_it_works_page():
 @app.route('/prompt-guide')
 def prompt_guide_page():
     return render_template('prompt_guide.html')
+
+
+@app.route('/users')
+@login_required
+def list_users_page():
+    """Display a simple table of registered users."""
+    if current_user.email != 'prendergast307@gmail.com':
+        abort(403)
+    users = User.query.all()
+    return render_template('users.html', users=users)
 
 
 @app.route('/dashboard')

--- a/templates/users.html
+++ b/templates/users.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>User List - NexusTrade AI</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Inter', sans-serif; background-color: #111827; color: #E5E7EB; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border-bottom: 1px solid #374151; padding: 0.75rem; text-align: left; }
+        th { background-color: #1F2937; }
+        tr:nth-child(even) { background-color: #1F2937; }
+    </style>
+</head>
+<body class="min-h-screen p-8">
+    <h1 class="text-2xl font-semibold mb-4">Registered Users</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Email</th>
+                <th>Paid</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for user in users %}
+            <tr>
+                <td>{{ user.id }}</td>
+                <td>{{ user.email }}</td>
+                <td>{{ 'Yes' if user.is_paid else 'No' }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/tests/test_password.py
+++ b/tests/test_password.py
@@ -1,6 +1,8 @@
+import os
 import sys
 from pathlib import Path
 
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from app import hash_pw, verify_pw
 

--- a/tests/test_users_page.py
+++ b/tests/test_users_page.py
@@ -1,0 +1,35 @@
+import os
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+from app import app, db, User, hash_pw
+import pytest
+
+app.config['TESTING'] = True
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    with app.app_context():
+        db.create_all()
+        admin = User(email='prendergast307@gmail.com', pw_hash=hash_pw('pw'))
+        user = User(email='other@example.com', pw_hash=hash_pw('pw'))
+        db.session.add_all([admin, user])
+        db.session.commit()
+        yield
+        db.session.remove()
+        db.drop_all()
+
+def login(client, email):
+    return client.post('/login', data={'email': email, 'password': 'pw'}, follow_redirects=True)
+
+def test_admin_can_access_users_page():
+    with app.test_client() as client:
+        login(client, 'prendergast307@gmail.com')
+        resp = client.get('/users')
+        assert resp.status_code == 200
+        assert b'prendergast307@gmail.com' in resp.data
+
+def test_normal_user_gets_403():
+    with app.test_client() as client:
+        login(client, 'other@example.com')
+        resp = client.get('/users')
+        assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- show all users via `/users` (admin-only)
- document restricted access in README
- test `/users` access for allowed and blocked users

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68624d86ea54833081110c8f9d737b42