### PR TITLE
Restrict /users page to admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The application reads configuration from environment variables using `python-dot
 - `HOSTED_PROMPT_ID` – optional ID for an OpenAI hosted prompt
 - `HOSTED_PROMPT_VERSION` – version number for the hosted prompt (default `1`)
 - `FLASK_DEBUG` – set to `1` to enable debug mode
+- `ADMIN_EMAIL` – email address allowed to access the `/users` page (default `harry.prendergast307@gmail.com`)
 
 ### Stripe pricing table
 
@@ -52,4 +53,6 @@ A simple `render.yaml` is included for deployment to Render. Adjust the environm
 
 ## Viewing Users
 
-Once logged in, you can visit `/users` to see a table of all registered accounts. The page displays each user's ID, email and whether they have completed payment.
+The `/users` page lists all registered accounts, showing each user's ID, email
+and payment status. Access to this page is restricted to the address specified
+by `ADMIN_EMAIL`.

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from flask import (
     redirect,
     session,
     flash,
+    abort,
 )
 import os
 import uuid  # For generating unique job IDs
@@ -88,6 +89,9 @@ stripe.api_key = os.environ.get('STRIPE_SECRET_KEY', '')
 STRIPE_PUBLISHABLE_KEY = os.environ.get('STRIPE_PUBLISHABLE_KEY', '')
 STRIPE_PRICE_ID = os.environ.get('STRIPE_PRICE_ID', '')
 STRIPE_PRICING_TABLE_ID = os.environ.get('STRIPE_PRICING_TABLE_ID', '')
+
+# Email allowed to view the /users page
+ADMIN_EMAIL = os.environ.get('ADMIN_EMAIL', 'harry.prendergast307@gmail.com')
 
 
 # --- Routes to serve your HTML pages ---
@@ -239,6 +243,8 @@ def prompt_guide_page():
 @login_required
 def list_users_page():
     """Display a simple table of registered users."""
+    if current_user.email != ADMIN_EMAIL:
+        abort(403)
     users = User.query.all()
     return render_template('users.html', users=users)
 


### PR DESCRIPTION
## Summary
- require `ADMIN_EMAIL` (defaulting to harry.prendergast307@gmail.com) to access `/users`
- document new `ADMIN_EMAIL` variable and update instructions about viewing users

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686252acffb08330af6729299c2f23f3