### PR TITLE
Add dollar signs to pricing

### DIFF
--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -32,7 +32,7 @@
                 <div class="order-summary p-6 rounded-lg space-y-3">
                     <div class="flex justify-between"><span class="text-gray-400">Selected Plan:</span><span id="selectedPlanName" class="font-medium text-white">Strategy Developer Pack</span></div>
                     <div class="flex justify-between"><span class="text-gray-400">Evaluation Frequency:</span><span id="evaluationFrequency" class="font-medium text-white">Every 30 minutes</span></div>
-                    <div class="flex justify-between border-t border-gray-700 pt-3 mt-3"><span class="text-lg font-semibold text-white">Total (One-Time):</span><span id="totalPrice" class="text-lg font-bold text-blue-400">40 NZD</span></div>
+                    <div class="flex justify-between border-t border-gray-700 pt-3 mt-3"><span class="text-lg font-semibold text-white">Total (One-Time):</span><span id="totalPrice" class="text-lg font-bold text-blue-400">$40 NZD</span></div>
                 </div>
             </div>
             <div class="disclaimer"><p><strong>Note:</strong> Payments are handled securely via Stripe. You will be redirected to complete checkout.</p></div>
@@ -57,9 +57,9 @@
         const evaluationFrequencyEl = document.getElementById('evaluationFrequency');
         const totalPriceEl = document.getElementById('totalPrice');
         if (plan === 'analyst') {
-            selectedPlanNameEl.textContent = 'High-Frequency Analyst Pack'; evaluationFrequencyEl.textContent = 'Every 2 minutes'; totalPriceEl.textContent = '1000 NZD';
+            selectedPlanNameEl.textContent = 'High-Frequency Analyst Pack'; evaluationFrequencyEl.textContent = 'Every 2 minutes'; totalPriceEl.textContent = '$1000 NZD';
         } else { // Default to developer pack or if no plan param
-            selectedPlanNameEl.textContent = 'Strategy Developer Pack'; evaluationFrequencyEl.textContent = 'Every 30 minutes'; totalPriceEl.textContent = '40 NZD';
+            selectedPlanNameEl.textContent = 'Strategy Developer Pack'; evaluationFrequencyEl.textContent = 'Every 30 minutes'; totalPriceEl.textContent = '$40 NZD';
         }
         const proceedButton = document.getElementById('proceedToPaymentButton');
         const pricingContainer = document.getElementById('stripePricingTable');

--- a/templates/index.html
+++ b/templates/index.html
@@ -205,7 +205,7 @@
                     <div class="pricing-content">
                         <h3 class="text-2xl font-bold text-white mb-2">Strategy Developer Pack</h3>
                         <p class="text-gray-400 mb-6">Ideal for in-depth strategy backtesting and refinement.</p>
-                        <p class="text-4xl font-extrabold text-white mb-1">40 NZD <span class="text-base font-medium text-gray-400">(One-Time Purchase)</span></p>
+                        <p class="text-4xl font-extrabold text-white mb-1">$40 NZD <span class="text-base font-medium text-gray-400">(One-Time Purchase)</span></p>
                         <p class="text-sm text-gray-500 mb-6">Access to evaluations every 30 minutes.</p>
                         <ul class="space-y-3 text-gray-300 mb-8">
                             <li class="flex items-center"><svg class="w-5 h-5 text-green-500 mr-2 shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path></svg>Full Backtesting Suite</li>
@@ -223,7 +223,7 @@
                     <div class="pricing-content">
                         <h3 class="text-2xl font-bold text-white mb-2 mt-4">High-Frequency Analyst Pack</h3>
                         <p class="text-gray-400 mb-6">For rapid iteration and fine-tuning with faster evaluations.</p>
-                        <p class="text-4xl font-extrabold text-white mb-1">1000 NZD <span class="text-base font-medium text-gray-400">(One-Time Purchase)</span></p>
+                        <p class="text-4xl font-extrabold text-white mb-1">$1000 NZD <span class="text-base font-medium text-gray-400">(One-Time Purchase)</span></p>
                         <p class="text-sm text-gray-500 mb-6">Access to evaluations every 2 minutes.</p>
                         <ul class="space-y-3 text-gray-300 mb-8">
                             <li class="flex items-center"><svg class="w-5 h-5 text-green-500 mr-2 shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path></svg>All Developer Pack Features</li>
@@ -235,7 +235,7 @@
                     <a href="/checkout?plan=analyst" class="mt-auto cta-button text-white text-center w-full px-6 py-3 rounded-lg font-semibold">Select Analyst Pack</a>
                 </div>
             </div>
-             <p class="text-center text-sm text-gray-400 mt-10">Note: Prices displayed as '40 NZD' and '1000 NZD' are illustrative. Real payment processing would be handled via a secure third-party gateway. Access to the Trading Lab is granted upon successful plan selection.</p>
+             <p class="text-center text-sm text-gray-400 mt-10">Note: Prices displayed as '$40 NZD' and '$1000 NZD' are illustrative. Real payment processing would be handled via a secure third-party gateway. Access to the Trading Lab is granted upon successful plan selection.</p>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- display pricing with a `$` symbol in index and checkout pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e5af5a808330aae1317b4f5eccb1