### PR TITLE
Fix hosted prompt call in backtester

### DIFF
--- a/my_backtester_logic.py
+++ b/my_backtester_logic.py
@@ -47,8 +47,7 @@ def call_hosted_prompt(
     client = OpenAI(api_key=api_key)
 
     resp = client.responses.create(
-        prompt={"id": prompt_id, "version": prompt_version},
-        variables=variables,
+        prompt={"id": prompt_id, "version": prompt_version, "variables": variables},
         model=model,
         response_format={"type": "json_object"},
         temperature=temperature,


### PR DESCRIPTION
## Summary
- adjust OpenAI hosted prompt parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a0f6a34d08330a1560dcff2386191