### PR TITLE
Fix hosted prompt compatibility with older OpenAI client

### DIFF
--- a/my_backtester_logic.py
+++ b/my_backtester_logic.py
@@ -45,13 +45,20 @@ def call_hosted_prompt(
     """Execute an OpenAI hosted prompt and return the raw JSON string."""
 
     client = OpenAI(api_key=api_key)
-
-    resp = client.responses.create(
-        prompt={"id": prompt_id, "version": prompt_version, "variables": variables},
-        model=model,
-        response_format={"type": "json_object"},
-        temperature=temperature,
-    )
+    try:
+        resp = client.responses.create(
+            prompt={"id": prompt_id, "version": prompt_version, "variables": variables},
+            model=model,
+            response_format={"type": "json_object"},
+            temperature=temperature,
+        )
+    except TypeError:
+        # Older openai versions do not support response_format
+        resp = client.responses.create(
+            prompt={"id": prompt_id, "version": prompt_version, "variables": variables},
+            model=model,
+            temperature=temperature,
+        )
     return resp.choices[0].message.content
 
 

--- a/promptexample.py
+++ b/promptexample.py
@@ -100,6 +100,14 @@ def call_openai(variables: dict, model: str, temperature: float) -> str:
             response_format={"type": "json_object"},
             temperature=temperature,
         )
+    except TypeError:
+        # Fallback for older openai versions without response_format support
+        resp = client.responses.create(
+            prompt={"id": prompt_id, "version": prompt_version},
+            variables=variables,
+            model=model,
+            temperature=temperature,
+        )
     except Error as exc:
         raise RuntimeError(f"OpenAI error: {exc}")
 


### PR DESCRIPTION
## Summary
- handle `response_format` argument for older versions of the OpenAI client
- add fallback logic in command line example script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b3ce31bcc8330b8c1e0cdd5f9e05a