### PR TITLE
Fix hosted prompt variable names

### DIFF
--- a/my_backtester_logic.py
+++ b/my_backtester_logic.py
@@ -196,9 +196,11 @@ def get_gpt_action_for_web(sub_df, current_balance, current_btc_holdings,
 
     try:
         if hosted_prompt_id:
+            # Match variable names expected by the hosted prompt template
             variables = {
-                "user_prompt": user_strategy_prompt_str,
-                "csv_block": formatted_data,
+                "strategy_prompt": user_strategy_prompt_str,
+                "data_block": formatted_data,
+                "user_message": "",
                 "ts": str(sub_df.index[-1])
             }
             content_from_llm = call_hosted_prompt(

--- a/promptexample.py
+++ b/promptexample.py
@@ -67,10 +67,11 @@ def collect_interactively(ns: argparse.Namespace):
 
 
 def build_variables(ns: argparse.Namespace) -> dict[str, str | float]:
+    """Return variables using names expected by the hosted prompt."""
     return {
-        "user_prompt": ns.prompt,
-        "template_block": "",                 # optional; kept for compatibility
-        "csv_block": "",                      # optional
+        "strategy_prompt": ns.prompt,
+        "data_block": "",       # optional placeholder for market data
+        "user_message": "",
 
         "ts": str(date.today()),
         "price": ns.price,


### PR DESCRIPTION
## Summary
- rename variables passed to the hosted prompt to match template expectations
- update CLI helper to build variables with the new names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b43b0ee508330a70d828ffb5a07f0