### PR TITLE
Fix variable usage for OpenAI hosted prompts

### DIFF
--- a/my_backtester_logic.py
+++ b/my_backtester_logic.py
@@ -47,8 +47,7 @@ def call_hosted_prompt(
     client = OpenAI(api_key=api_key)
     try:
         resp = client.responses.create(
-            prompt={"id": prompt_id, "version": prompt_version},
-            variables=variables,
+            prompt={"id": prompt_id, "version": prompt_version, "variables": variables},
             model=model,
             response_format={"type": "json_object"},
             temperature=temperature,
@@ -56,8 +55,7 @@ def call_hosted_prompt(
     except TypeError:
         # Older openai versions do not support response_format
         resp = client.responses.create(
-            prompt={"id": prompt_id, "version": prompt_version},
-            variables=variables,
+            prompt={"id": prompt_id, "version": prompt_version, "variables": variables},
             model=model,
             temperature=temperature,
         )

--- a/promptexample.py
+++ b/promptexample.py
@@ -95,8 +95,7 @@ def call_openai(variables: dict, model: str, temperature: float) -> str:
 
     try:
         resp = client.responses.create(
-            prompt={"id": prompt_id, "version": prompt_version},
-            variables=variables,
+            prompt={"id": prompt_id, "version": prompt_version, "variables": variables},
             model=model,
             response_format={"type": "json_object"},
             temperature=temperature,
@@ -104,8 +103,7 @@ def call_openai(variables: dict, model: str, temperature: float) -> str:
     except TypeError:
         # Fallback for older openai versions without response_format support
         resp = client.responses.create(
-            prompt={"id": prompt_id, "version": prompt_version},
-            variables=variables,
+            prompt={"id": prompt_id, "version": prompt_version, "variables": variables},
             model=model,
             temperature=temperature,
         )


### PR DESCRIPTION
## Summary
- ensure variables are included in the `prompt` field when calling `client.responses.create`
- keep fallback logic for older OpenAI versions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b5f04fd70833083983edd9f464949