### PR TITLE
Fix openai hosted prompt call

### DIFF
--- a/my_backtester_logic.py
+++ b/my_backtester_logic.py
@@ -45,21 +45,12 @@ def call_hosted_prompt(
     """Execute an OpenAI hosted prompt and return the raw JSON string."""
 
     client = OpenAI(api_key=api_key)
-    try:
-        resp = client.responses.create(
-            prompt={"id": prompt_id, "version": prompt_version, "variables": variables},
-            model=model,
-            response_format={"type": "json_object"},
-            temperature=temperature,
-        )
-    except TypeError:
-        # Older openai versions do not support response_format
-        resp = client.responses.create(
-            prompt={"id": prompt_id, "version": prompt_version, "variables": variables},
-            model=model,
-            temperature=temperature,
-        )
-    return resp.choices[0].message.content
+    resp = client.responses.create(
+        prompt={"id": prompt_id, "version": prompt_version, "variables": variables},
+        model=model,
+        temperature=temperature,
+    )
+    return resp.output_text
 
 
 


### PR DESCRIPTION
## Summary
- avoid using response_format with OpenAI's responses API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b70eb25648330a4cc2dd8c6b71c05