### PR TITLE
Remove response_format argument

### DIFF
--- a/my_backtester_logic.py
+++ b/my_backtester_logic.py
@@ -211,7 +211,6 @@ def get_gpt_action_for_web(sub_df, current_balance, current_btc_holdings,
             response = openai.chat.completions.create(
                 model=gpt_model_param,
                 messages=[{"role": "user", "content": prompt_to_send}],
-                response_format={"type": "json_object"},
                 temperature=0.3
             )
             content_from_llm = response.choices[0].message.content

--- a/promptexample.py
+++ b/promptexample.py
@@ -97,14 +97,6 @@ def call_openai(variables: dict, model: str, temperature: float) -> str:
         resp = client.responses.create(
             prompt={"id": prompt_id, "version": prompt_version, "variables": variables},
             model=model,
-            response_format={"type": "json_object"},
-            temperature=temperature,
-        )
-    except TypeError:
-        # Fallback for older openai versions without response_format support
-        resp = client.responses.create(
-            prompt={"id": prompt_id, "version": prompt_version, "variables": variables},
-            model=model,
             temperature=temperature,
         )
     except Error as exc:


### PR DESCRIPTION
## Summary
- drop `response_format` option when calling OpenAI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b75a5f698833082c291b546a09263