### PR TITLE
Scale GPT confidence and gate delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The application reads configuration from environment variables using `python-dot
 - `OPENAI_API_KEY` – optional key used by the backtester logic
 - `HOSTED_PROMPT_ID` – optional ID for an OpenAI hosted prompt
 - `HOSTED_PROMPT_VERSION` – version number for the hosted prompt (default `1`)
+- `ENABLE_API_CALL_BUFFER` – set to `1` to wait after LLM calls (default disables delay)
 - `FLASK_DEBUG` – set to `1` to enable debug mode
 - `ADMIN_EMAIL` – email address allowed to access the `/users` page (default `harry.prendergast307@gmail.com`)
 


### PR DESCRIPTION
## Summary
- scale GPT confidence to 0-100 and warn when <1%
- only sleep after API calls when `ENABLE_API_CALL_BUFFER=1`
- document new env var in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c953d21f08330bc9cc0bc9909a5bf