### PR TITLE
Update gunicorn timeout in render spec

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     buildCommand: |
       pip install -r requirements.txt
     startCommand: |
-      flask db upgrade && gunicorn app:app
+      flask db upgrade && gunicorn app:app --timeout 120 --bind 0.0.0.0:$PORT --workers 2
 
     disk:                  # ← add this block
       name: data           # arbitrary label
@@ -15,5 +15,3 @@ services:
     envVars:
       - key: DATA_DIR      # optional; lets app find the disk path
         value: /data
-      - key: GUNICORN_CMD_ARGS
-        value: "--timeout 120"


### PR DESCRIPTION
## Summary
- add `--timeout 120` to gunicorn command in `render.yaml`
- remove old GUNICORN_CMD_ARGS env var

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c9f3282fc8330b55dde19eb1e224a