### PR TITLE
Add progress bar for backtests

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,6 +54,10 @@ app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 db = SQLAlchemy(app)
 migrate = Migrate(app, db)
 
+# In-memory progress tracking for backtest jobs
+# Maps job_id -> percentage integer
+job_progress = {}
+
 # Login manager setup
 login_manager = LoginManager(app)
 login_manager.login_view = "login_page"
@@ -306,8 +310,9 @@ def handle_run_backtest():
                 app.logger.info("Using built-in BTC data")
 
             csv_file_path = None
-            job_id = str(uuid.uuid4())
+            job_id = request.form.get("job_id") or str(uuid.uuid4())
             app.logger.info(f"Generated Job ID: {job_id}")
+            job_progress[job_id] = 0
 
             if not openai_key:
                 app.logger.error("Server OpenAI API key not configured.")
@@ -379,6 +384,7 @@ def handle_run_backtest():
                 start_balance=start_balance,
                 trade_amount_btc=trade_amount_btc,
                 # api_call_buffer_seconds and gpt_model_to_use will use defaults from my_backtester_logic.py
+                progress_callback=lambda pct: job_progress.__setitem__(job_id, pct),
             )
 
             if "error" in backtest_results_data:
@@ -409,6 +415,12 @@ def handle_run_backtest():
                 ),
                 500,
             )
+
+
+@app.route("/status/<job_id>")
+def get_job_status(job_id):
+    pct = int(job_progress.get(job_id, 0))
+    return jsonify({"pct": pct})
 
 
 # Route to serve result files from the dynamic job_id subdirectories

--- a/templates/member_dashboard.html
+++ b/templates/member_dashboard.html
@@ -193,6 +193,7 @@
 
                             <div class="pt-4">
                                 <button type="submit" id="runBacktestButton" class="w-full cta-button text-white px-6 py-3 rounded-lg font-semibold shadow-lg">Run Backtest</button>
+                                <progress id="bt-bar" value="0" max="100" class="w-full h-2 bg-gray-700 mt-2 hidden"></progress>
                             </div>
                         </form>
                     </div>
@@ -284,6 +285,26 @@
         const totalTradesText = document.getElementById('totalTradesText');
         const tradeLogLink = document.getElementById('tradeLogLink');
         const equityCurveLink = document.getElementById('equityCurveLink');
+        const progressBar = document.getElementById('bt-bar');
+
+        function watchProgress(jobId) {
+            if (!progressBar) return;
+            progressBar.hidden = false;
+            progressBar.value = 0;
+            const interval = setInterval(async () => {
+                try {
+                    const res = await fetch(`/status/${jobId}`);
+                    if (!res.ok) return;
+                    const data = await res.json();
+                    progressBar.value = data.pct;
+                    if (data.pct >= 100) {
+                        clearInterval(interval);
+                    }
+                } catch (err) {
+                    console.error('Progress poll failed', err);
+                }
+            }, 1000);
+        }
 
         if (backtestingForm) {
             backtestingForm.addEventListener('submit', async function(event) {
@@ -299,6 +320,10 @@
                 resultsArea.classList.remove('hidden');
 
                 const formData = new FormData(backtestingForm);
+                const jobId = crypto.randomUUID();
+                formData.append('job_id', jobId);
+                watchProgress(jobId);
+                jobIdText.textContent = jobId;
 
                 // Log FormData contents for debugging
                 // for (let [key, value] of formData.entries()) {
@@ -358,14 +383,17 @@
                         tradeLogLink.style.display = 'inline';
                         equityCurveLink.href = data.results.equity_curve_url; // Link to the image itself
                         equityCurveLink.style.display = 'inline';
+                        progressBar.hidden = true;
                     } else if (data.error) {
                         statusText.textContent = `Error: ${data.error}`;
                         equityCurvePlaceholder.innerHTML = `<p class="text-red-400">Error: ${data.error}</p><p>${data.details || ''}</p>`;
+                        progressBar.hidden = true;
                     }
                 } catch (error) {
                     console.error('Error submitting backtest:', error);
                     statusText.textContent = 'Failed to run backtest.';
                     equityCurvePlaceholder.innerHTML = `<p class="text-red-400">An error occurred: ${error.message}. Check browser console and Flask server logs for details.</p>`;
+                    progressBar.hidden = true;
                 }
             });
         }


### PR DESCRIPTION
## Summary
- track job progress in memory
- report status via `/status/<job_id>`
- update backtest logic to send progress updates
- display progress bar on member dashboard and poll status

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68807140d0c883308c13bc3efeaec29f