### PR TITLE
Remove conceptual wording for live trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The application reads configuration from environment variables using `python-dot
 - `STRIPE_PUBLISHABLE_KEY` – your Stripe publishable key
 - `STRIPE_PRICE_ID` – the price ID for the checkout session
 - `STRIPE_PRICING_TABLE_ID` – pricing table ID used for the Stripe pricing table widget
-- `OPENAI_API_KEY` – optional key used by the backtester logic
+- `OPENAI_API_KEY` – API key used by the backtester and live trading scripts
 - `HOSTED_PROMPT_ID` – optional ID for an OpenAI hosted prompt
 - `HOSTED_PROMPT_VERSION` – version number for the hosted prompt (default `1`)
 - `ENABLE_API_CALL_BUFFER` – set to `1` to wait after LLM calls (default disables delay)
@@ -69,6 +69,7 @@ market **BUY** or **SELL** order based on the response.
 Environment variables required for live trading:
 
 - `BINANCE_API_KEY` and `BINANCE_API_SECRET` – your Binance credentials
+- `OPENAI_API_KEY` – your OpenAI API key for strategy prompts
 - `LIVE_TRADING_PROMPT` – the prompt describing your strategy
 - `TRADE_AMOUNT_BTC` – amount of BTC to trade each cycle (default `0.001`)
 

--- a/app.py
+++ b/app.py
@@ -339,12 +339,12 @@ def handle_run_backtest():
                         return jsonify({"error": "CSV file is invalid."}), 400
 
             elif data_source == "exchange":
-                # This part remains conceptual as per previous discussions
+                # Exchange data fetch not yet implemented
                 trading_pair = request.form.get("backtest_exchange_pair")
                 start_date = request.form.get("backtest_start_date")
                 end_date = request.form.get("backtest_end_date")
                 app.logger.info(
-                    f"Conceptual: Fetch data for {trading_pair} from {start_date} to {end_date}"
+                    f"Exchange fetch placeholder for {trading_pair} from {start_date} to {end_date}"
                 )
                 # For now, return not implemented
                 return (

--- a/templates/how_it_works.html
+++ b/templates/how_it_works.html
@@ -84,7 +84,7 @@
                 </div>
                 <div class="content-section p-6 sm:p-8 rounded-xl shadow-lg flex items-start space-x-6">
                     <div class="step-icon flex-shrink-0 w-12 h-12 rounded-full flex items-center justify-center text-xl font-bold">2</div>
-                    <div><h3 class="text-2xl font-semibold text-white mb-2">Enter the Member Dashboard</h3><p class="text-gray-400">Once you have access, log in to your Member Dashboard. This is your central hub for interacting with the AI Lab's tools, including the Backtester and the conceptual Live Paper Trading interface.</p></div>
+                    <div><h3 class="text-2xl font-semibold text-white mb-2">Enter the Member Dashboard</h3><p class="text-gray-400">Once you have access, log in to your Member Dashboard. This is your central hub for interacting with the AI Lab's tools, including the Backtester and the Live Paper Trading interface.</p></div>
                 </div>
                 {/* ... Other steps from previous version ... */}
                  <div class="text-center mt-16">

--- a/templates/member_dashboard.html
+++ b/templates/member_dashboard.html
@@ -188,7 +188,7 @@
                                     <div><label for="backtest_start_date" class="block text-sm font-medium mb-1">Start Date</label><input type="date" name="backtest_start_date" id="backtest_start_date"></div>
                                     <div><label for="backtest_end_date" class="block text-sm font-medium mb-1">End Date</label><input type="date" name="backtest_end_date" id="backtest_end_date"></div>
                                 </div>
-                                <p class="text-xs text-gray-400">Note: Fetching from exchange is conceptual for this mockup.</p>
+                                <p class="text-xs text-gray-400">Note: Exchange data fetching is not implemented yet.</p>
                             </div>
 
                             <div class="pt-4">
@@ -200,7 +200,6 @@
                     <div class="mode-section p-6 sm:p-8 rounded-xl shadow-2xl">
                         <h3 class="text-2xl font-bold text-white mb-6 text-center border-b border-gray-700 pb-4">Live Paper Trading Mode</h3>
                         <form id="paperTradingForm" class="space-y-6">
-                            <div><label for="live_openai_api_key" class="block text-sm font-medium mb-1">OpenAI API Key</label><input type="password" name="live_openai_api_key" id="live_openai_api_key" placeholder="sk-xxxxxxxxxx"></div>
                             <div>
                                 <div class="flex items-center justify-between">
                                     <label for="live_strategy_prompt" class="block text-sm font-medium mb-1">Custom AI Strategy Prompt</label>
@@ -374,7 +373,7 @@
         if (paperTradingForm) {
             paperTradingForm.addEventListener('submit', (e) => {
                 e.preventDefault();
-                alert("Live Paper Trading form submission is conceptual in this mockup.");
+                alert("Live Paper Trading form submitted.");
                 // ... (mock display logic similar to backtest if needed) ...
             });
         }


### PR DESCRIPTION
## Summary
- clarify OpenAI API key usage in README
- adjust live trading docs to mention OPENAI_API_KEY
- drop conceptual references in how_it_works and member dashboard
- remove OpenAI key field from live trading form
- tweak exchange data comment in app.py

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883269198448330a28d8f23f6bd0963