### PR TITLE
Add live trading control routes

### DIFF
--- a/live_trading.py
+++ b/live_trading.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import os
 import time
 import logging


### PR DESCRIPTION
## Summary
- allow launching live paper trading in a background subprocess
- allow stopping live paper trading
- track running processes in memory
- make `live_trading.py` directly executable

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883348ce0dc8330aa44298c161f0e1e