### PR TITLE
Ensure demo backtest only shows profits

### DIFF
--- a/app.py
+++ b/app.py
@@ -313,7 +313,12 @@ def guest_run_backtest():
     job_dir = os.path.join(RESULTS_FOLDER, job_id)
     os.makedirs(job_dir, exist_ok=True)
 
-    equity = 10000 + np.cumsum(np.random.randn(50) * 50)
+    # Generate an upward-trending equity curve so the demo always
+    # showcases profits instead of potential losses. Start at $10k and
+    # accumulate only positive changes to ensure the final equity is
+    # higher than the initial balance.
+    equity_changes = np.abs(np.random.randn(49) * 50)
+    equity = 10000 + np.insert(np.cumsum(equity_changes), 0, 0)
     plt.figure(figsize=(8, 4))
     plt.plot(equity, color="#3B82F6")
     plt.title("Guest Backtest Equity Curve")

--- a/templates/guest_backtest.html
+++ b/templates/guest_backtest.html
@@ -193,9 +193,11 @@
 
                         if (data.status === 'completed') {
                             equityCurveImage.src = data.results.equity_curve_url;
-                            finalEquityText.textContent = `$${data.results.final_equity.toFixed(2)}`;
-                            const netPL = data.results.net_pl;
-                            netPLText.textContent = `${netPL >= 0 ? '+' : ''}$${netPL.toFixed(2)}`;
+                            const startingBalance = parseFloat(document.getElementById('demo_starting_balance').value);
+                            const netPL = Math.max(0, data.results.net_pl);
+                            const finalEquity = startingBalance + netPL;
+                            finalEquityText.textContent = `$${finalEquity.toFixed(2)}`;
+                            netPLText.textContent = `+$${netPL.toFixed(2)}`;
                         }
                     } catch (error) {
                         console.error('Error running demo backtest:', error);


### PR DESCRIPTION
## Summary
- Ensure guest backtest equity curve trends upward so demo results always show profits
- Clamp negative profit/loss values in the guest demo UI and recalculate final equity

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac538674bc8330b6325c7f9ad00ee9