### PR TITLE
Include reasoning in live signal responses

### DIFF
--- a/app.py
+++ b/app.py
@@ -77,6 +77,7 @@ latest_live_signal_status = {
     "usd_balance": 0.0,
     "btc_balance": 0.0,
     "estimated_pl": 0.0,
+    "reason": "",
     "message": "AI Signal Generator is not active.",
     "type": "info",
 }
@@ -508,6 +509,7 @@ def start_live_signal_generator():
             "usd_balance": float(initial_usd_balance),
             "btc_balance": 0.0,
             "estimated_pl": 0.0,
+            "reason": "",
             "message": "AI Signal Generator starting...",
             "type": "info",
             "session_id": session_id,

--- a/dashboardEx.html
+++ b/dashboardEx.html
@@ -534,7 +534,8 @@
                 const signal = data.signal || 'HOLD';
                 const usd_balance = data.usd_balance !== undefined ? data.usd_balance : currentSimulatedUSD;
                 const btc_balance = data.btc_balance !== undefined ? data.btc_balance : currentSimulatedBTC;
-                const message = data.message || `AI signaled ${signal}.`;
+                const reason = data.reason || '';
+                const message = data.message || `AI signaled ${signal}.${reason ? ` Reason: ${reason}` : ''}`;
 
                 aiSignal.textContent = signal;
                 aiSignal.className = 'signal-text'; // Reset classes

--- a/gemini.py
+++ b/gemini.py
@@ -121,7 +121,8 @@ def run_live_trading():
                     "usd_balance": trader.usdt_balance,
                     "btc_balance": trader.btc_balance,
                     "estimated_pl": trader.get_net_pl(current_price), # You'll need to implement this in SimulatedTrader
-                    "recent_activity_message": f"AI signaled {action}. Reason: {reasoning[:50]}...",
+                    "reason": reasoning,
+                    "message": f"AI signaled {action}. Reason: {reasoning[:50]}...",
                     "type": action.lower() # for log coloring
                 }
                 requests.post(FLASK_STATUS_ENDPOINT, json=report_data)

--- a/live_trading.py
+++ b/live_trading.py
@@ -110,7 +110,8 @@ def run_live_trading():
                 "usd_balance": trader.usdt_balance,
                 "btc_balance": trader.btc_balance,
                 "estimated_pl": trader.get_net_pl(price),
-                "message": f"AI signaled {action}.",
+                "reason": reasoning,
+                "message": f"AI signaled {action}. Reason: {reasoning}",
             }
             if FLASK_STATUS_ENDPOINT:
                 try:

--- a/templates/member_dashboard.html
+++ b/templates/member_dashboard.html
@@ -559,7 +559,8 @@ ACTION CONFIDENCE% REASONING`;
                 const signal = data.signal || 'HOLD';
                 const usd_balance = data.usd_balance !== undefined ? data.usd_balance : currentSimulatedUSD;
                 const btc_balance = data.btc_balance !== undefined ? data.btc_balance : currentSimulatedBTC;
-                const message = data.message || `AI signaled ${signal}.`;
+                const reason = data.reason || '';
+                const message = data.message || `AI signaled ${signal}.${reason ? ` Reason: ${reason}` : ''}`;
 
                 aiSignal.textContent = signal;
                 aiSignal.className = 'signal-text'; // Reset classes


### PR DESCRIPTION
## Summary
- send reasoning along with each live signal payload and message
- propagate reason through Flask status tracking
- show reasoning in dashboards with fallback messages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac5cf779e08330ace223d501ad99f4