### PR TITLE
Limit backtests to one day by default

### DIFF
--- a/app.py
+++ b/app.py
@@ -361,9 +361,11 @@ def handle_run_backtest():
         try:
             openai_key = os.environ.get("OPENAI_API_KEY")
             strategy_prompt = request.form.get("backtest_strategy_prompt")
-            # Default to '7' if not provided or empty, then convert to int
-            num_days_str = request.form.get("backtest_days_csv", "7")
-            num_days = int(num_days_str) if num_days_str else 7
+            # Default to '1' if not provided or empty, then convert to int
+            num_days_str = request.form.get("backtest_days_csv", "1")
+            num_days = int(num_days_str) if num_days_str else 1
+            # Enforce a maximum of 3 days and a minimum of 1 day
+            num_days = max(1, min(num_days, 3))
 
             randomize_period_str = request.form.get(
                 "backtest_randomize_period_csv", "yes"

--- a/dashboardEx.html
+++ b/dashboardEx.html
@@ -216,7 +216,7 @@
                                     </div>
                                     <div>
                                         <label for="backtest_days_csv" class="block text-sm font-medium mb-1">Days to Backtest from CSV</label>
-                                        <input type="number" name="backtest_days_csv" id="backtest_days_csv" value="7" min="1">
+                                        <input type="number" name="backtest_days_csv" id="backtest_days_csv" value="1" min="1" max="3">
                                     </div>
                                 </div>
                                 <div>

--- a/templates/member_dashboard.html
+++ b/templates/member_dashboard.html
@@ -218,7 +218,7 @@
                                     </div>
                                     <div>
                                         <label for="backtest_days_csv" class="block text-sm font-medium mb-1">Days to Backtest from CSV</label>
-                                        <input type="number" name="backtest_days_csv" id="backtest_days_csv" value="7" min="1">
+                                        <input type="number" name="backtest_days_csv" id="backtest_days_csv" value="1" min="1" max="3">
                                     </div>
                                 </div>
                                 <div>

--- a/templates/prompt_guide.html
+++ b/templates/prompt_guide.html
@@ -151,7 +151,7 @@
             <p>For your first run, we recommend keeping the backtest duration short:</p>
             <ul>
                 <li>In the "Days to Backtest from CSV" field, enter <code>1</code>.</li>
-                <li>**Important Note:** Backtesting longer periods (e.g., 7 days) involves significantly more API calls to the AI model and can lead to very high wait times or even timeouts. For faster results and initial testing, **1 day is highly recommended.**</li>
+                <li>**Important Note:** Backtesting longer periods (up to the 3-day limit) involves significantly more API calls to the AI model and can lead to very high wait times or even timeouts. For faster results and initial testing, **1 day is highly recommended.**</li>
             </ul>
 
             <h3>Step 5: Run the Backtest</h3>


### PR DESCRIPTION
## Summary
- Default backtests to one day and enforce a three-day maximum
- Update dashboard forms to use one-day default with three-day cap
- Clarify prompt guide note about the new three-day backtest limit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac5e8f5fe08330b4b6c7e14974f54c