### PR TITLE
Add profile page and username-based leaderboard

### DIFF
--- a/dashboardEx.html
+++ b/dashboardEx.html
@@ -101,7 +101,7 @@
                 <div class="hidden md:block">
                     <div class="ml-10 flex items-baseline space-x-4">
                         <a href="#lab" class="bg-gray-700 text-white px-3 py-2 rounded-md text-sm font-medium">Trading Lab</a>
-                        <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">My Profile (Conceptual)</a>
+                        <a href="/profile" class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">My Profile</a>
                         <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Billing (Conceptual)</a>
                         <a href="/logout" id="logoutLink" class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Logout</a>
                     </div>
@@ -118,7 +118,7 @@
         <div class="md:hidden hidden" id="dashboard-mobile-menu">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
                 <a href="#lab" class="bg-gray-700 text-white block px-3 py-2 rounded-md text-base font-medium">Trading Lab</a>
-                <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium">My Profile</a>
+                <a href="/profile" class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium">My Profile</a>
                 <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium">Billing</a>
                 <a href="/logout" id="logoutLinkMobile" class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium">Logout</a>
             </div>

--- a/migrations/versions/8b2c343d2f34_add_username_and_show_on_leaderboard.py
+++ b/migrations/versions/8b2c343d2f34_add_username_and_show_on_leaderboard.py
@@ -1,0 +1,27 @@
+"""Add username and show_on_leaderboard to User
+
+Revision ID: 8b2c343d2f34
+Revises: de97489c4113
+Create Date: 2025-08-25 16:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '8b2c343d2f34'
+down_revision = 'de97489c4113'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('username', sa.String(length=80), nullable=True))
+        batch_op.add_column(sa.Column('show_on_leaderboard', sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('show_on_leaderboard')
+        batch_op.drop_column('username')

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -120,7 +120,7 @@
                         <td>
                             <span class="rank-badge">{{ loop.index }}</span>
                         </td>
-                        <td>{{ user.email }}</td>
+                        <td>{{ user.username or user.email }}</td>
                         <td class="{{ 'net-pl-positive' if user.total_net_pl > 0 else 'net-pl-negative' }}">
                             ${{ "%.2f"|format(user.total_net_pl) }}
                         </td>

--- a/templates/member_dashboard.html
+++ b/templates/member_dashboard.html
@@ -98,7 +98,7 @@
                 <div class="hidden md:block">
                     <div class="ml-10 flex items-baseline space-x-4">
                         <a href="#lab" class="bg-gray-700 text-white px-3 py-2 rounded-md text-sm font-medium">Trading Lab</a>
-                        <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">My Profile (Conceptual)</a>
+                        <a href="/profile" class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">My Profile</a>
                         <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Billing (Conceptual)</a>
                         <a href="/leaderboard" class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Leaderboard</a>
                         <a href="/logout" id="logoutLink" class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Logout</a>
@@ -116,7 +116,7 @@
         <div class="md:hidden hidden" id="dashboard-mobile-menu">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
                 <a href="#lab" class="bg-gray-700 text-white block px-3 py-2 rounded-md text-base font-medium">Trading Lab</a>
-                <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium">My Profile</a>
+                <a href="/profile" class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium">My Profile</a>
                 <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium">Billing</a>
                 <a href="/leaderboard" class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium">Leaderboard</a>
                 <a href="/logout" id="logoutLinkMobile" class="text-gray-300 hover:bg-gray-700 hover:text-white block px-3 py-2 rounded-md text-base font-medium">Logout</a>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -101,7 +101,7 @@
             <form method="POST" action="{{ url_for('profile_page') }}" class="mt-6 space-y-6">
                 <div>
                     <label for="username" class="form-label block mb-2">Username</label>
-                    <input type="text" id="username" name="username" value="{{ current_user.username }}" required class="block w-full">
+                    <input type="text" id="username" name="username" value="{{ current_user.username or '' }}" required class="block w-full">
                 </div>
                 <div>
                     <label for="email" class="form-label block mb-2">Email Address</label>


### PR DESCRIPTION
## Summary
- store usernames and leaderboard opt-in in `User`
- add profile page for updating username and leaderboard visibility
- show usernames on leaderboard and navigation links to profile

## Testing
- `pytest`
- `flask db migrate -m "add username and show_on_leaderboard"` *(fails: Target database is not up to date)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8681f1c883308903d2c8b1d8cea0