### PR TITLE
Ensure default admin user exists

### DIFF
--- a/app.py
+++ b/app.py
@@ -142,6 +142,31 @@ STRIPE_PRICING_TABLE_ID = os.environ.get("STRIPE_PRICING_TABLE_ID", "")
 ADMIN_EMAIL = os.environ.get("ADMIN_EMAIL", "harry.prendergast307@gmail.com")
 
 
+def ensure_admin_user() -> None:
+    """Ensure an admin user exists with access to the /users page."""
+    with app.app_context():
+        if User.query.filter_by(email=ADMIN_EMAIL).first():
+            return
+
+        base_username = ADMIN_EMAIL.split("@")[0]
+        username = base_username
+        counter = 1
+        while User.query.filter_by(username=username).first():
+            username = f"{base_username}{counter}"
+            counter += 1
+
+        admin_user = User(
+            email=ADMIN_EMAIL,
+            pw_hash=hash_pw("Pindar0065"),
+            is_paid=True,
+            username=username,
+            show_on_leaderboard=False,
+        )
+        db.session.add(admin_user)
+        db.session.commit()
+        app.logger.info(f"Created admin user {ADMIN_EMAIL}")
+
+
 # --- Routes to serve your HTML pages ---
 @app.route("/")
 def home():

--- a/run.py
+++ b/run.py
@@ -2,7 +2,12 @@ import os
 import sys
 from io import StringIO
 from contextlib import redirect_stderr
-from app import app, add_sample_users_for_leaderboard, update_leaderboard_in_background
+from app import (
+    app,
+    add_sample_users_for_leaderboard,
+    ensure_admin_user,
+    update_leaderboard_in_background,
+)
 import threading
 
 def run_migrations_and_server():
@@ -36,6 +41,9 @@ def run_migrations_and_server():
                     print(error_output)
                     sys.exit(1)
     
+    print("Ensuring admin user exists...")
+    ensure_admin_user()
+
     # Add demo users on every startup for a robust demo experience
     print("Adding sample users for leaderboard...")
     add_sample_users_for_leaderboard()


### PR DESCRIPTION
## Summary
- Create helper to seed an admin account and allow access to the `/users` page
- Run admin seeding during startup before adding sample users

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad33ffa51083309ed38e1a3c4e9ab4