### PR TITLE
Use Werkzeug auth and resilient background thread

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,9 +4,10 @@ services:
     runtime: python        # “env: python” → “runtime:” in new spec
     buildCommand: |
       pip install -r requirements.txt
+    preDeployCommand: |
+      FLASK_APP=app.py flask db upgrade
     startCommand: |
-      flask db upgrade || (flask db stamp head && flask db upgrade)
-      gunicorn app:app --timeout 120 --bind 0.0.0.0:$PORT --workers 2
+      gunicorn app:app --timeout 300 --bind 0.0.0.0:$PORT --workers 2
     disk:                  # ← add this block
       name: data           # arbitrary label
       mountPath: /data     # absolute, non-root path
@@ -15,3 +16,5 @@ services:
     envVars:
       - key: DATA_DIR      # optional; lets app find the disk path
         value: /data
+      - key: SECRET_KEY
+        generateValue: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ flask
 flask-login
 flask-sqlalchemy
 flask-migrate
-passlib[bcrypt]
 python-dotenv
 stripe
 openai>=1.14.0


### PR DESCRIPTION
## Summary
- replace passlib/bcrypt with Werkzeug `generate_password_hash` and `check_password_hash`
- use env-driven `SECRET_KEY`, consistent SQLite path, and env-configurable demo sleep
- start leaderboard updater once per worker via hook and update Render config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad3a2dc4e88330b098aef31e2dc982