### PR TITLE
Add admin dashboard to manage users and leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,15 @@ During local development you can use `http://127.0.0.1:5000` in place of `https:
 
 A simple `render.yaml` is included for deployment to Render. Adjust the environment variables there as needed.
 
-## Viewing Users
+## Admin Dashboard
 
-The `/users` page lists all registered accounts, showing each user's ID, email
-and payment status. Access to this page is restricted to the address specified
-by `ADMIN_EMAIL`.
+The `/admin` page is restricted to the address specified by `ADMIN_EMAIL`
+(default `harry.prendergast307@gmail.com`). From this page the administrator
+can add or remove users and edit leaderboard statistics such as total P&L,
+number of backtests, and whether a user appears on the public leaderboard.
+
+The simpler `/users` page still lists all registered accounts and remains
+accessible only to the admin as well.
 
 ## Live Trading (Experimental)
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Dashboard - NexusTrade AI</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Inter', sans-serif; background-color: #111827; color: #E5E7EB; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border-bottom: 1px solid #374151; padding: 0.75rem; text-align: left; }
+        th { background-color: #1F2937; }
+        tr:nth-child(even) { background-color: #1F2937; }
+    </style>
+</head>
+<body class="min-h-screen p-8">
+    <h1 class="text-2xl font-semibold mb-4">Admin Dashboard</h1>
+
+    <h2 class="text-xl font-semibold mb-2">Add User</h2>
+    <form method="POST" class="mb-8">
+        <input type="hidden" name="action" value="add_user">
+        <div class="mb-2">
+            <label class="block">Email</label>
+            <input type="email" name="email" required class="w-full p-2 rounded bg-gray-800" />
+        </div>
+        <div class="mb-2">
+            <label class="block">Password</label>
+            <input type="password" name="password" required class="w-full p-2 rounded bg-gray-800" />
+        </div>
+        <div class="mb-4">
+            <label>
+                <input type="checkbox" name="is_paid"> Paid Member
+            </label>
+        </div>
+        <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Add User</button>
+    </form>
+
+    <h2 class="text-xl font-semibold mb-2">Manage Users</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Email</th>
+                <th>Manage</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for user in users %}
+            <tr>
+                <td>{{ user.id }}</td>
+                <td>{{ user.email }}</td>
+                <td>
+                    <form method="POST" class="flex items-center space-x-2">
+                        <input type="number" step="any" name="total_net_pl" value="{{ user.total_net_pl }}" class="w-24 p-1 rounded bg-gray-800">
+                        <input type="number" name="total_backtests" value="{{ user.total_backtests }}" class="w-20 p-1 rounded bg-gray-800">
+                        <input type="checkbox" name="show_on_leaderboard" {% if user.show_on_leaderboard %}checked{% endif %}>
+                        <input type="hidden" name="user_id" value="{{ user.id }}">
+                        <button type="submit" name="action" value="update_leaderboard" class="px-2 py-1 bg-green-600 text-white rounded">Save</button>
+                        <button type="submit" name="action" value="delete_user" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Delete this user?')">Delete</button>
+                    </form>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `/admin` route restricted to `ADMIN_EMAIL` for user and leaderboard management
- allow admin to add or remove users and update leaderboard stats
- document new admin dashboard and capabilities

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad5c9fe354833096360bb6087ff3cb