### PR TITLE
Track unique page views and expose in admin dashboard

### DIFF
--- a/migrations/versions/d1f7b65e4b00_add_page_view_table.py
+++ b/migrations/versions/d1f7b65e4b00_add_page_view_table.py
@@ -1,0 +1,31 @@
+"""Add PageView table
+
+Revision ID: d1f7b65e4b00
+Revises: 8b2c343d2f34
+Create Date: 2024-08-26 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'd1f7b65e4b00'
+down_revision = '8b2c343d2f34'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'page_view',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('ip_address', sa.String(length=45), nullable=False),
+        sa.Column('user_agent', sa.String(length=255), nullable=False),
+        sa.Column('first_seen', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('ip_address', 'user_agent', name='uniq_page_view')
+    )
+
+
+def downgrade():
+    op.drop_table('page_view')

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -17,6 +17,9 @@
 <body class="min-h-screen p-8">
     <h1 class="text-2xl font-semibold mb-4">Admin Dashboard</h1>
 
+    <h2 class="text-xl font-semibold mb-2">Site Statistics</h2>
+    <p class="mb-8">Unique device views: {{ unique_views }}</p>
+
     <h2 class="text-xl font-semibold mb-2">Add User</h2>
     <form method="POST" class="mb-8">
         <input type="hidden" name="action" value="add_user">

--- a/tests/test_page_views.py
+++ b/tests/test_page_views.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from app import app, db, PageView
+import os
+
+
+def setup_module(module):
+    os.makedirs('/data', exist_ok=True)
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+
+def test_unique_page_views():
+    with app.app_context():
+        db.session.query(PageView).delete()
+        db.session.commit()
+        client = app.test_client()
+
+        client.get('/', headers={'User-Agent': 'UA1'}, environ_base={'REMOTE_ADDR': '1.1.1.1'})
+        assert PageView.query.count() == 1
+
+        client.get('/', headers={'User-Agent': 'UA1'}, environ_base={'REMOTE_ADDR': '1.1.1.1'})
+        assert PageView.query.count() == 1
+
+        client.get('/', headers={'User-Agent': 'UA2'}, environ_base={'REMOTE_ADDR': '2.2.2.2'})
+        assert PageView.query.count() == 2


### PR DESCRIPTION
## Summary
- add `PageView` model and tracking helper to record first-time visits by IP and user agent
- display total unique devices on admin dashboard
- test unique page view tracking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad6658b15483309f140bdac6acf58f